### PR TITLE
Provide tooling for reversing nested collection relationships

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,9 @@ AllCops:
 Metrics/LineLength:
   Enabled: false
 
+Metrics/AbcSize:
+  Max: 17
+
 Style/CollectionMethods:
   PreferredMethods:
     collect: 'map'
@@ -43,7 +46,7 @@ RSpec/NamedSubject:
 RSpec/MultipleExpectations:
   Exclude:
     - spec/hydra/pcdm/collection_indexer_spec.rb
-    - spec/hydra/pcdm/object_indexer_spec.rb
+    - spec/hydra/pcdm/pcdm_indexer_spec.rb
     - spec/hydra/pcdm/models/*
 
 RSpec/ExampleLength:

--- a/lib/hydra/pcdm/models/concerns/object_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/object_behavior.rb
@@ -49,18 +49,6 @@ module Hydra::PCDM
       #     @return [ActiveFedora::Associations::ContainerProxy]
       directly_contains :files, has_member_relation: Vocab::PCDMTerms.hasFile,
                                 class_name: 'Hydra::PCDM::File'
-
-      ##
-      # @macro [new] indirectly_contains
-      #   @!method $1
-      #     @return [ActiveFedora::Associations::ContainerProxy]
-      indirectly_contains :member_of_collections,
-                          has_member_relation: Vocab::PCDMTerms.memberOf,
-                          inserted_content_relation: RDF::Vocab::ORE.proxyFor,
-                          class_name: 'ActiveFedora::Base',
-                          through: 'ActiveFedora::Aggregation::Proxy',
-                          foreign_key: :target,
-                          type_validator: Validators::PCDMCollectionValidator
     end
 
     ##
@@ -95,12 +83,6 @@ module Hydra::PCDM
     # @return [Enumerable<Hydra::PCDM::ObjectBehavior>]
     def in_objects
       member_of.select(&:pcdm_object?).to_a
-    end
-
-    ##
-    # @return [Enumerable<String>]
-    def member_of_collection_ids
-      member_of_collections.map(&:id)
     end
 
     ##

--- a/lib/hydra/pcdm/models/concerns/pcdm_behavior.rb
+++ b/lib/hydra/pcdm/models/concerns/pcdm_behavior.rb
@@ -42,6 +42,18 @@ module Hydra::PCDM
                                             inserted_content_relation: RDF::Vocab::ORE.proxyFor, class_name: 'ActiveFedora::Base',
                                             through: 'ActiveFedora::Aggregation::Proxy', foreign_key: :target,
                                             type_validator: Validators::PCDMObjectValidator
+
+      ##
+      # @macro [new] indirectly_contains
+      #   @!method $1
+      #     @return [ActiveFedora::Associations::ContainerProxy]
+      indirectly_contains :member_of_collections,
+                          has_member_relation: Vocab::PCDMTerms.memberOf,
+                          inserted_content_relation: RDF::Vocab::ORE.proxyFor,
+                          class_name: 'ActiveFedora::Base',
+                          through: 'ActiveFedora::Aggregation::Proxy',
+                          foreign_key: :target,
+                          type_validator: Validators::PCDMCollectionValidator
     end
 
     ##
@@ -111,6 +123,12 @@ module Hydra::PCDM
     # @return [Enumerable<String>] ids for collections the object is a member of
     def in_collection_ids
       in_collections.map(&:id)
+    end
+
+    ##
+    # @return [Enumerable<String>]
+    def member_of_collection_ids
+      member_of_collections.map(&:id)
     end
 
     ##

--- a/lib/hydra/pcdm/object_indexer.rb
+++ b/lib/hydra/pcdm/object_indexer.rb
@@ -1,9 +1,4 @@
 module Hydra::PCDM
   class ObjectIndexer < PCDMIndexer
-    def generate_solr_document
-      super.tap do |solr_doc|
-        solr_doc[Config.indexing_member_of_collection_ids_key] = object.member_of_collection_ids
-      end
-    end
   end
 end

--- a/lib/hydra/pcdm/pcdm_indexer.rb
+++ b/lib/hydra/pcdm/pcdm_indexer.rb
@@ -6,6 +6,7 @@ module Hydra::PCDM
         solr_doc[Config.indexing_member_ids_key] += object.member_ids
         solr_doc[Config.indexing_member_ids_key].uniq!
         solr_doc[Config.indexing_object_ids_key] = object.ordered_object_ids
+        solr_doc[Config.indexing_member_of_collection_ids_key] = object.member_of_collection_ids
       end
     end
   end

--- a/spec/hydra/pcdm/models/collection_spec.rb
+++ b/spec/hydra/pcdm/models/collection_spec.rb
@@ -569,6 +569,29 @@ describe Hydra::PCDM::Collection do
     end
   end
 
+  describe 'membership in collections' do
+    subject do
+      collection = described_class.new
+      collection.member_of_collections = [collection1, collection2]
+      collection
+    end
+
+    let(:collection1) { described_class.create }
+    let(:collection2) { described_class.create }
+
+    describe '#member_of_collections' do
+      it 'contains collections the object is a member of' do
+        expect(subject.member_of_collections).to match_array [collection1, collection2]
+      end
+    end
+
+    describe '#member_of_collection_ids' do
+      it 'contains the ids of collections the object is a member of' do
+        expect(subject.member_of_collection_ids).to match_array [collection1.id, collection2.id]
+      end
+    end
+  end
+
   describe '.indexer' do
     after do
       Object.send(:remove_const, :Foo)

--- a/spec/hydra/pcdm/object_indexer_spec.rb
+++ b/spec/hydra/pcdm/object_indexer_spec.rb
@@ -4,13 +4,10 @@ describe Hydra::PCDM::ObjectIndexer do
   let(:object)        { Hydra::PCDM::Object.new }
   let(:child_object1) { Hydra::PCDM::Object.new(id: '123') }
   let(:child_object2) { Hydra::PCDM::Object.new(id: '456') }
-  let(:collection1)   { Hydra::PCDM::Collection.new(id: 'abc') }
-  let(:collection2)   { Hydra::PCDM::Collection.new(id: 'def') }
   let(:indexer)       { described_class.new(object) }
 
   before do
     allow(object).to receive(:ordered_object_ids).and_return([child_object1.id, child_object2.id])
-    allow(object).to receive(:member_of_collection_ids).and_return([collection1.id, collection2.id])
   end
 
   describe '#generate_solr_document' do
@@ -18,7 +15,6 @@ describe Hydra::PCDM::ObjectIndexer do
 
     it 'has fields' do
       expect(subject[Hydra::PCDM::Config.indexing_object_ids_key]).to eq %w(123 456)
-      expect(subject[Hydra::PCDM::Config.indexing_member_of_collection_ids_key]).to eq %w(abc def)
     end
   end
 end

--- a/spec/hydra/pcdm/pcdm_indexer_spec.rb
+++ b/spec/hydra/pcdm/pcdm_indexer_spec.rb
@@ -4,9 +4,12 @@ describe Hydra::PCDM::PCDMIndexer do
   let(:collection) { Hydra::PCDM::Collection.new }
   let(:member_ids) { %w(123 456 789) }
   let(:indexer) { described_class.new(collection) }
+  let(:collection1)   { Hydra::PCDM::Collection.new(id: 'abc') }
+  let(:collection2)   { Hydra::PCDM::Collection.new(id: 'def') }
 
   before do
     allow(collection).to receive(:member_ids).and_return(member_ids)
+    allow(collection).to receive(:member_of_collection_ids).and_return([collection1.id, collection2.id])
   end
 
   describe '#generate_solr_document' do
@@ -14,6 +17,7 @@ describe Hydra::PCDM::PCDMIndexer do
 
     it 'has fields' do
       expect(subject[Hydra::PCDM::Config.indexing_member_ids_key]).to eq %w(123 456 789)
+      expect(subject[Hydra::PCDM::Config.indexing_member_of_collection_ids_key]).to eq %w(abc def)
     end
   end
 end


### PR DESCRIPTION
This PR allows for reversing the collection->sub-collection relationship. It leverages the work @escowles did (#227) for reversing the collection->object relationship by pulling the relavant code up from the object module into the pcdm module for model behavior and indexer.  This will increase the performance for collections with many sub-collections which may be more common in dSpace instances.

Future work could be allowing the object->object relationship to be reversed.  This could set the stage for a refactoring of the model behaviors and possibly other modules and classes in hydra-pcdm.

Resolves #243.