### PR TITLE
Pin Rails to 5.1

### DIFF
--- a/hydra-pcdm.gemspec
+++ b/hydra-pcdm.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'active-fedora', '>= 10', '< 13'
+  spec.add_dependency 'activesupport', '< 5.2'
   spec.add_dependency 'mime-types', '>= 1'
 
   spec.add_development_dependency 'bundler', '~> 1.6'


### PR DESCRIPTION
AF `12.0` will soon pin to Rails 5.1 - in the meantime we can get a
working release of 1.0 out by doing this.

Closes #251