### PR TITLE
Revert "Pin Rails to 5.1"

### DIFF
--- a/hydra-pcdm.gemspec
+++ b/hydra-pcdm.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'active-fedora', '>= 10', '< 13'
-  spec.add_dependency 'activesupport', '< 5.2'
   spec.add_dependency 'mime-types', '>= 1'
 
   spec.add_development_dependency 'bundler', '~> 1.6'


### PR DESCRIPTION
Reverts samvera/hydra-pcdm#263
ActiveFedora 12.0.2 was released which pins to rails 5.1.  Removing this pin will allow `hydra-pcdm` to work with rails 5.2 once ActiveFedora 12.1.0 is released.