### PR TITLE
Removes CodeClimate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Code:
 [![Version](https://badge.fury.io/rb/hydra-pcdm.png)](http://badge.fury.io/rb/hydra-pcdm)
 [![Build Status](https://circleci.com/gh/samvera/hydra-pcdm.svg?style=svg)](https://circleci.com/gh/samvera/hydra-pcdm)
 [![Coverage Status](https://coveralls.io/repos/samvera/hydra-pcdm/badge.svg?branch=master)](https://coveralls.io/r/samvera/hydra-pcdm?branch=master)
-[![Code Climate](https://codeclimate.com/github/projecthydra/hydra-pcdm/badges/gpa.svg)](https://codeclimate.com/github/projecthydra/hydra-pcdm)
 
 Docs:
 [![Apache 2.0 License](http://img.shields.io/badge/APACHE2-license-blue.svg)](./LICENSE)


### PR DESCRIPTION
Hydra-PCDM appears not to be using CodeClimate, so we should remove the badge.

If CodeClimate was set up, we would see builds here: https://codeclimate.com/github/samvera/hydra-pcdm/builds

Fixes #278 