### PR TITLE
remove outdated bundler dependency

### DIFF
--- a/hydra-pcdm.gemspec
+++ b/hydra-pcdm.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mime-types', '>= 1'
   spec.add_dependency 'rdf-vocab', '<=3.1.4'
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'fcrepo_wrapper', '~> 0.1'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
there's no need to specify this, and it is very very old.