### PR TITLE
Adds Circle CI step that fails if branch name is master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,15 @@ jobs:
       RAILS_VERSION: << parameters.rails_version >>
     steps:
       - samvera/cached_checkout
-
+      - run:
+          name: Check for a branch named 'master'
+          command: |
+            git fetch --all --quiet --prune --prune-tags
+            if [[ -n "$(git branch --all --list master */master)" ]]; then
+              echo "A branch named 'master' was found. Please remove it."
+              echo "$(git branch --all --list master */master)"
+            fi
+            [[ -z "$(git branch --all --list master */master)" ]]
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>


### PR DESCRIPTION
Deprecates https://github.com/samvera/hydra-pcdm/pull/284. Resolves #283.